### PR TITLE
We fixed FONT by setFont before getMetrics()

### DIFF
--- a/src/entity/WordObject.java
+++ b/src/entity/WordObject.java
@@ -42,11 +42,11 @@ public abstract class WordObject extends Entity {
         g2.drawImage(image, x, y, 5 * GamePanel.TILE_SIZE / 4, 5 * GamePanel.TILE_SIZE / 4, null);
         
         // draw Enemy's Word
+        g2.setFont(FONT);
         int width = g2.getFontMetrics().stringWidth(word);
         g2.setColor(Color.WHITE);
         g2.fillRect(x + (GamePanel.TILE_SIZE - width)/2 - 10, y - 25, width + 20, g2.getFontMetrics().getHeight());
         
-        g2.setFont(FONT);
         g2.setColor(Color.BLACK);
         g2.drawRect(x + (GamePanel.TILE_SIZE - (g2.getFontMetrics().stringWidth(word)))/2 - 10, y - 25, g2.getFontMetrics().stringWidth(word) + 20, g2.getFontMetrics().getHeight());
         g2.drawString(word, x + (GamePanel.TILE_SIZE - (g2.getFontMetrics().stringWidth(word)))/2, y - 10);


### PR DESCRIPTION
## 🛠️ What was fixed

- Fixed incorrect background sizing for text labels in the game UI.
- The issue was caused by calling `getFontMetrics()` **before** setting the desired font, leading to inaccurate text height/width calculations.

## 🎯 Changes

- Reordered the code so `setFont()` is called **before** `getFontMetrics()` in the text drawing method.

## 📎 Notes

- Remember: Always set the font before getting `FontMetrics`, otherwise you may measure the wrong text size.
