### PR TITLE
Remove useless commandNum variable on GameStateManager use in GameState instead

### DIFF
--- a/src/gamestate/GameStateManager.java
+++ b/src/gamestate/GameStateManager.java
@@ -11,19 +11,16 @@ import game_2d.GamePanel;
  * @author HP
  */
 public class GameStateManager {
-    private int commandNum;
     private GameState currentState;
     private GamePanel gp;
 
     public GameStateManager(GamePanel gp) {
         this.gp = gp;
-        this.commandNum = 0;
         this.currentState = new TitleMainState(this);
     }
 
     public void changeGameState() {
         currentState.changeState();
-        commandNum = 0;
     }
 
     public void setState(GameState newState) {
@@ -33,14 +30,6 @@ public class GameStateManager {
 
     public GameState getCurrentState() {
         return currentState;
-    }
-
-    public void setCommandNum(int num) {
-        this.commandNum = num;
-    }
-
-    public int getCommandNum() {
-        return commandNum;
     }
 
     public GamePanel getGamePanel() {

--- a/src/ui/UI.java
+++ b/src/ui/UI.java
@@ -126,7 +126,7 @@ public class UI {
                     GamePanel.SCREEN_WIDTH / 2 - pauseButton.getWidth() + 2 * GamePanel.TILE_SIZE,
                 GamePanel.SCREEN_HEIGHT / 2 + GamePanel.TILE_SIZE,
                 9 * GamePanel.TILE_SIZE, 2 * GamePanel.TILE_SIZE);
-        if(gp.getGameStateManager().getCommandNum() == 0) drawCursorMenu(GamePanel.SCREEN_WIDTH / 2 - pauseButton.getWidth() + 2 * GamePanel.TILE_SIZE,
+        if(gp.getGameStateManager().getCurrentState().getCommandNum() == 0) drawCursorMenu(GamePanel.SCREEN_WIDTH / 2 - pauseButton.getWidth() + 2 * GamePanel.TILE_SIZE,
                 GamePanel.SCREEN_HEIGHT / 2 + 3 * GamePanel.TILE_SIZE / 2);
     }
     


### PR DESCRIPTION
## What's Change?
- Remove commandNum variable on GameStateManager Class
- if we want to use commandNum variable just use from others Class GameState.